### PR TITLE
Make things smaller and add support for .NET 8

### DIFF
--- a/src/SmolSharp.Mandelbrot/Program.cs
+++ b/src/SmolSharp.Mandelbrot/Program.cs
@@ -7,7 +7,7 @@ namespace SmolSharp.Raytracer
 {
     internal static class Program
     {
-        static void Main(string[] args) { }
+        static void Main() { }
 
         [UnmanagedCallersOnly(EntryPoint = "smolsharp_main")]
         public static unsafe int UnmanagedMain(nint hInstance, nint hPrevInstance, char* pCmdLine, int nCmdShow)

--- a/src/SmolSharp.Ocean/Program.cs
+++ b/src/SmolSharp.Ocean/Program.cs
@@ -12,7 +12,7 @@ namespace SmolSharp.Ocean
         static ushort windowWidth, windowHeight;
         static bool windowDimensionsChanged;
 
-        static void Main(string[] args) { }
+        static void Main() { }
 
         [UnmanagedCallersOnly(EntryPoint = "smolsharp_main")]
         public static unsafe int UnmanagedMain(nint hInstance, nint hPrevInstance, char* pCmdLine, int nCmdShow)

--- a/src/SmolSharp.props
+++ b/src/SmolSharp.props
@@ -17,8 +17,6 @@
 		<IlcSystemModule>$(MSBuildProjectName)</IlcSystemModule>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<EntryPointSymbol>smolsharp_main</EntryPointSymbol>
-		<PublishTrimmed>true</PublishTrimmed>
-		<TrimmerRemoveSymbols>true</TrimmerRemoveSymbols>
 		<DebugType>none</DebugType>
 	</PropertyGroup>
 
@@ -41,6 +39,7 @@
 		<LinkerArg Include="/nodefaultlib"></LinkerArg>
 		<LinkerArg Include="/fixed"></LinkerArg> <!-- disabling relocations makes the linker skip emitting the .reloc section, which saves us about ~100 bytes -->
 		<LinkerArg Include="/merge:.modules=.rdata"></LinkerArg>
+		<LinkerArg Include="/merge:.managedcode=.text"></LinkerArg>
 		<LinkerArg Include="user32.lib"></LinkerArg>
 		<LinkerArg Include="shell32.lib"></LinkerArg>
 		<LinkerArg Include="gdi32.lib"></LinkerArg>
@@ -48,9 +47,11 @@
 
 	<PropertyGroup>
 		<IlcDisableReflection>true</IlcDisableReflection>
-		<DynamicCodeSupport>false</DynamicCodeSupport>
-		<IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+		<StackTraceSupport>false</StackTraceSupport> <!-- .NET 8+ -->
+		<IlcGenerateStackTraceData>false</IlcGenerateStackTraceData> <!-- < .NET 8 -->
 		<IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
+		<IlcDehydrate>false</IlcDehydrate>
+		<IlcGenerateWin32Resources>false</IlcGenerateWin32Resources> <!-- .NET 8 -->
 		<Optimize>true</Optimize>
 		<OptimizationPreference>Size</OptimizationPreference>
 	</PropertyGroup>
@@ -91,6 +92,15 @@
 		<TrimNullBytes TargetPath="$(NativeBinary)"/> 
 	</Target>
 
+	<Target Name="RemoveIlcSwitches" BeforeTargets="IlcCompile" DependsOnTargets="WriteIlcRspFileForCompilation">
+		<ItemGroup>
+			<IlcArg Remove="--runtimeknob:RUNTIME_IDENTIFIER=win-x64" />
+			<IlcArg Remove="--resilient" />
+		</ItemGroup>
+		<WriteLinesToFile File="%(ManagedBinary.IlcRspFile)" Lines="@(IlcArg)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+	</Target>
+
+	<!-- < .NET 8 -->
 	<Target Name="RemoveWin32Resources" BeforeTargets="LinkNative" Outputs="$(_Win32ResFile)">
 		<PropertyGroup>
 			<_Win32ResFile></_Win32ResFile>


### PR DESCRIPTION
* Merge `.managedcode` into `.text`.
* Remove `string[]` from `Main` that brings in a bunch of garbage
* Add support for .NET 8 (but keep the projects at .NET 7). Upgrading to .NET 8 will be a size improvement for Ocean, but a regression for the rest.
* Remove a couple things from the .props file that don't do anything.
* Update README.md with new sizes