### PR TITLE
Fix signature for Decompress

### DIFF
--- a/src/SmolSharp.Ocean/Program.cs
+++ b/src/SmolSharp.Ocean/Program.cs
@@ -145,14 +145,14 @@ namespace SmolSharp.Ocean
             var compressedFragShader = OceanShader.FragmentShader();
             var fragBuffer = Kernel32.GlobalAlloc(default, 8192);
             nint hDcmp;
-            ulong fragLength;
+            nint fragLength;
             bool success;
 
             success = CompressAPI.CreateDecompressor(CompressAlgorithm.MSZip, default, &hDcmp);
             success = CompressAPI.Decompress(
                 hDcmp,
                 compressedFragShader.AsPointer(),
-                (ulong)compressedFragShader.Length,
+                compressedFragShader.Length,
                 fragBuffer,
                 8192,
                 &fragLength

--- a/src/SmolSharp.Win32/CompressAPI.cs
+++ b/src/SmolSharp.Win32/CompressAPI.cs
@@ -16,10 +16,10 @@ namespace SmolSharp.Win32
         public static extern bool Decompress(
             nint decompressorHandle,
             void* compressedData,
-            ulong compressedDataSize,
+            nint compressedDataSize,
             void* uncompressedBuffer,
             nint uncompressedBufferSize,
-            ulong* uncompressedDataSize
+            nint* uncompressedDataSize
         );
     }
 


### PR DESCRIPTION
This is a size_t in the header. long doesn't work for 32-bit.