### PR TITLE
Compile as x86

### DIFF
--- a/src/BFlat.ZeroLib/Internal/Stubs.cs
+++ b/src/BFlat.ZeroLib/Internal/Stubs.cs
@@ -161,7 +161,7 @@ assigningNull:
         static unsafe MethodTable** AllocObject(uint size)
         {
 #if WINDOWS
-            [DllImport("kernel32")]
+            [DllImport("kernel32", EntryPoint = "_LocalAlloc@8")]
             static extern MethodTable** LocalAlloc(uint flags, uint size);
             MethodTable** result = LocalAlloc(0x40, size);
 #elif LINUX

--- a/src/BFlat.ZeroLib/System/Console.Windows.cs
+++ b/src/BFlat.ZeroLib/System/Console.Windows.cs
@@ -28,7 +28,7 @@ namespace System
             TRUE = 1,
         }
 
-        [DllImport("kernel32")]
+        [DllImport("kernel32", EntryPoint = "_GetStdHandle@4")]
         private static unsafe extern IntPtr GetStdHandle(int c);
 
         private readonly static IntPtr s_outputHandle = GetStdHandle(-11);
@@ -181,7 +181,7 @@ namespace System
             SetConsoleCursorPosition(s_outputHandle, new COORD { X = (short)x, Y = (short)y });
         }
 
-        [DllImport("kernel32", EntryPoint = "WriteConsoleW")]
+        [DllImport("kernel32", EntryPoint = "_WriteConsoleW@20")]
         private static unsafe extern BOOL WriteConsole(IntPtr handle, void* buffer, int numChars, int* charsWritten, void* reserved);
 
         public static unsafe void Write(char c)

--- a/src/BFlat.ZeroLib/System/Environment.Windows.cs
+++ b/src/BFlat.ZeroLib/System/Environment.Windows.cs
@@ -27,7 +27,7 @@ namespace System
 
         public static long TickCount64 => GetTickCount64();
 
-        [DllImport("kernel32")]
+        [DllImport("kernel32", EntryPoint = "_RaiseFailFastException@12")]
         private static extern void RaiseFailFastException(IntPtr a, IntPtr b, int flags);
 
         public static void FailFast(string message)

--- a/src/SmolSharp.HelloWorld/SmolSharp.HelloWorld.csproj
+++ b/src/SmolSharp.HelloWorld/SmolSharp.HelloWorld.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/src/SmolSharp.Mandelbrot/SmolSharp.Mandelbrot.csproj
+++ b/src/SmolSharp.Mandelbrot/SmolSharp.Mandelbrot.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/src/SmolSharp.Ocean/SmolSharp.Ocean.csproj
+++ b/src/SmolSharp.Ocean/SmolSharp.Ocean.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/src/SmolSharp.Win32/CompressAPI.cs
+++ b/src/SmolSharp.Win32/CompressAPI.cs
@@ -5,14 +5,14 @@ namespace SmolSharp.Win32
 {
     internal static unsafe class CompressAPI
     {
-        [SuppressGCTransition, DllImport("Cabinet")]
+        [SuppressGCTransition, DllImport("Cabinet", EntryPoint = "_CreateDecompressor@12")]
         public static extern bool CreateDecompressor(
             CompressAlgorithm algorithm,
             nint allocationRoutines,
             nint* decompressorHandle
         );
 
-        [SuppressGCTransition, DllImport("Cabinet")]
+        [SuppressGCTransition, DllImport("Cabinet", EntryPoint = "_Decompress@24")]
         public static extern bool Decompress(
             nint decompressorHandle,
             void* compressedData,

--- a/src/SmolSharp.Win32/GDI/Gdi32.cs
+++ b/src/SmolSharp.Win32/GDI/Gdi32.cs
@@ -6,27 +6,27 @@ namespace SmolSharp.Win32.GDI
 {
     internal static unsafe class Gdi32
     {
-        [SuppressGCTransition, DllImport("gdi32")]
+        [SuppressGCTransition, DllImport("gdi32", EntryPoint = "_SetPixel@16")]
         public static extern uint SetPixel(
             nint hdc,
             int x, int y,
             uint color
         );
 
-        [SuppressGCTransition, DllImport("gdi32")]
+        [SuppressGCTransition, DllImport("gdi32", EntryPoint = "_ChoosePixelFormat@8")]
         public static extern int ChoosePixelFormat(
             nint hdc,
             PixelFormatDescriptor* ppfd
         );
 
-        [SuppressGCTransition, DllImport("gdi32")]
+        [SuppressGCTransition, DllImport("gdi32", EntryPoint = "_SetPixelFormat@12")]
         public static extern bool SetPixelFormat(
             nint hdc,
             int format,
             PixelFormatDescriptor* ppfd
         );
 
-        [SuppressGCTransition, DllImport("gdi32")]
+        [SuppressGCTransition, DllImport("gdi32", EntryPoint = "_SwapBuffers@4")]
         public static extern bool SwapBuffers(
             nint hdc
         );

--- a/src/SmolSharp.Win32/GDI/OpenGL/GL.cs
+++ b/src/SmolSharp.Win32/GDI/OpenGL/GL.cs
@@ -15,11 +15,11 @@ namespace SmolSharp.Win32.GDI.OpenGL
         public const uint TRIANGLES = 0x4;
 
         [SuppressGCTransition]
-        [DllImport("opengl32", EntryPoint = "wglCreateContext")]
+        [DllImport("opengl32", EntryPoint = "_wglCreateContext@4")]
         public static extern nint CreateContext(nint hdc);
 
         [SuppressGCTransition]
-        [DllImport("opengl32", EntryPoint = "wglMakeCurrent")]
+        [DllImport("opengl32", EntryPoint = "_wglMakeCurrent@8")]
         public static extern bool MakeCurrent(nint hdc, nint ctx);
 
         [SuppressGCTransition]
@@ -31,11 +31,11 @@ namespace SmolSharp.Win32.GDI.OpenGL
         public static extern void Clear(uint mask);
 
         [SuppressGCTransition]
-        [DllImport("opengl32", EntryPoint = "wglGetProcAddress")]
+        [DllImport("opengl32", EntryPoint = "_wglGetProcAddress@4")]
         public static unsafe extern void* GetProcAddress(byte* name);
 
         [SuppressGCTransition]
-        [DllImport("opengl32", EntryPoint = "glDrawArrays")]
+        [DllImport("opengl32", EntryPoint = "_glDrawArrays@12")]
         public static extern void DrawArrays(
             uint mode,
             int first,
@@ -43,7 +43,7 @@ namespace SmolSharp.Win32.GDI.OpenGL
         );
 
         [SuppressGCTransition]
-        [DllImport("opengl32", EntryPoint = "glViewport")]
+        [DllImport("opengl32", EntryPoint = "_glViewport@16")]
         public static extern void Viewport(int x, int y, uint width, uint height);
 
         [SuppressGCTransition]

--- a/src/SmolSharp.Win32/Kernel32.cs
+++ b/src/SmolSharp.Win32/Kernel32.cs
@@ -5,7 +5,7 @@ namespace SmolSharp.Win32
 {
     internal static unsafe class Kernel32
     {
-        [SuppressGCTransition, DllImport("kernel32")]
+        [SuppressGCTransition, DllImport("kernel32", EntryPoint = "_CreateThread@24")]
         public static extern nint CreateThread(
             nint threadAttributes,
             nint stackSize,
@@ -15,13 +15,13 @@ namespace SmolSharp.Win32
             nint lpThreadId = 0
         );
 
-        [SuppressGCTransition, DllImport("kernel32")]
+        [SuppressGCTransition, DllImport("kernel32", EntryPoint = "_GlobalAlloc@8")]
         public static extern void* GlobalAlloc(uint dwFlags, nint dwBytes);
 
-        [SuppressGCTransition, DllImport("kernel32")]
+        [SuppressGCTransition, DllImport("kernel32", EntryPoint = "_AllocConsole@0")]
         public static extern bool AllocConsole();
 
-        [SuppressGCTransition, DllImport("kernel32")]
+        [SuppressGCTransition, DllImport("kernel32", EntryPoint = "_Sleep@4")]
         public static extern void Sleep(uint ms);
     }
 }

--- a/src/SmolSharp.Win32/User32.cs
+++ b/src/SmolSharp.Win32/User32.cs
@@ -7,7 +7,7 @@ namespace SmolSharp.Win32
     internal static unsafe class User32
     {
         [SuppressGCTransition]
-        [DllImport("user32", EntryPoint = "CreateWindowExA")]
+        [DllImport("user32", EntryPoint = "_CreateWindowExA@48")]
         public static extern nint CreateWindowEx(
             uint dwExStyles,
             void* lpClassName,
@@ -24,15 +24,15 @@ namespace SmolSharp.Win32
         );
 
         [SuppressGCTransition]
-        [DllImport("user32", EntryPoint = "RegisterClassA")]
+        [DllImport("user32", EntryPoint = "_RegisterClassA@4")]
         public static extern nint RegisterClass(WindowClassA* lpWndClass);
 
         [SuppressGCTransition]
-        [DllImport("user32", EntryPoint = "ShowWindow")]
+        [DllImport("user32", EntryPoint = "_ShowWindow@8")]
         public static extern nint ShowWindow(nint hWnd, int nCmdShow);
 
         [SuppressGCTransition]
-        [DllImport("user32", EntryPoint = "GetMessageA")]
+        [DllImport("user32", EntryPoint = "_GetMessageA@16")]
         public static extern int GetMessage(
             WndMessage* lpMsg,
             nint hwnd,
@@ -45,11 +45,11 @@ namespace SmolSharp.Win32
         public static extern bool TranslateMessage(WndMessage* lpMsg);
 
         [SuppressGCTransition]
-        [DllImport("user32", EntryPoint = "DispatchMessageA")]
+        [DllImport("user32", EntryPoint = "_DispatchMessageA@4")]
         public static extern bool DispatchMessage(WndMessage* lpMsg);
 
         [SuppressGCTransition]
-        [DllImport("user32", EntryPoint = "DefWindowProcA")]
+        [DllImport("user32", EntryPoint = "_DefWindowProcA@16")]
         public static extern nint DefWindowProc(
             nint hwnd,
             uint msg,
@@ -58,7 +58,7 @@ namespace SmolSharp.Win32
         );
 
         [SuppressGCTransition]
-        [DllImport("user32")]
+        [DllImport("user32", EntryPoint = "_GetDC@4")]
         public static extern nint GetDC(nint hwnd);
 
         //[DllImport("user32")]

--- a/src/SmolSharp.Win32/WinMM.cs
+++ b/src/SmolSharp.Win32/WinMM.cs
@@ -6,7 +6,7 @@ namespace SmolSharp.Win32
     internal static class WinMM
     {
         [SuppressGCTransition]
-        [DllImport("winmm.dll", EntryPoint = "timeGetTime")]
+        [DllImport("winmm.dll", EntryPoint = "_timeGetTime@0")]
         public static extern uint GetTime();
     }
 }

--- a/src/SmolSharp.props
+++ b/src/SmolSharp.props
@@ -43,6 +43,7 @@
 		<LinkerArg Include="user32.lib"></LinkerArg>
 		<LinkerArg Include="shell32.lib"></LinkerArg>
 		<LinkerArg Include="gdi32.lib"></LinkerArg>
+		<LinkerArg Include="&quot;$(IntermediateOutputPath)x86-stubs.obj&quot;"></LinkerArg>
 	</ItemGroup>
 
 	<PropertyGroup>
@@ -105,6 +106,16 @@
 		<PropertyGroup>
 			<_Win32ResFile></_Win32ResFile>
 		</PropertyGroup>
+	</Target>
+
+	<Target Name="RewriteToX86" BeforeTargets="SetupOSSpecificProps">
+		<PropertyGroup>
+			<_targetArchitecture>x86</_targetArchitecture>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="BuildX86Stubs" AfterTargets="SetupOSSpecificProps" BeforeTargets="LinkNative">
+		<Exec Command="&quot;$(_CppToolsDirectory)\ml.exe&quot; /c /Fo&quot;$(IntermediateOutputPath)x86-stubs.obj&quot; &quot;$(MSBuildThisFileDirectory)x86-stubs.asm&quot;" />
 	</Target>
 
 	<Target Name="RemoveSDKLibs" AfterTargets="SetupOSSpecificProps">

--- a/src/x86-stubs.asm
+++ b/src/x86-stubs.asm
@@ -1,0 +1,49 @@
+.586
+.xmm
+.model  flat
+
+.const
+align 8
+
+_Int32ToUInt32  DQ  0000000000000000H
+                DQ  41F0000000000000H       ; 2**32
+_DP2to32        EQU (_Int32ToUInt32+8)
+
+.code
+
+PUBLIC RhpLng2Dbl
+RhpLng2Dbl PROC
+  mov      edx,dword ptr [esp+8]
+  mov      ecx,dword ptr [esp+4]
+  xorps    xmm1,xmm1
+  cvtsi2sd xmm1,edx              ; convert (signed) upper bits
+  xorps    xmm0,xmm0
+  cvtsi2sd xmm0,ecx              ; convert (signed) lower bits
+  shr      ecx,31                ; get sign bit into ecx
+  mulsd    xmm1,_DP2to32         ; adjust upper value for bit position
+  addsd    xmm0,_Int32ToUInt32[ecx*8] ; adjust to unsigned
+  addsd    xmm0,xmm1             ; combine upper and lower
+  movsd    mmword ptr [esp+4],xmm0
+  fld      qword ptr [esp+4]
+  ret
+RhpLng2Dbl ENDP
+
+PUBLIC RhpByRefAssignRef
+RhpByRefAssignRef PROC
+  movs    dword ptr es:[edi],dword ptr [esi]  
+  ret
+RhpByRefAssignRef ENDP
+
+PUBLIC RhpCheckedAssignRefEAX
+RhpCheckedAssignRefEAX PROC
+  ;
+  ; This is not tested. Once you validate this does what it should, remove this int 3
+  int 3
+  ;
+
+  mov     DWORD PTR [edx], eax
+  ret
+RhpCheckedAssignRefEAX ENDP
+
+
+end


### PR DESCRIPTION
ILC (the Native AOT compiler) is a crosscompiler and ships with x86 support even though we don't actually have it fully implemented for Native AOT in mainstream .NET. Since SmolSharp only uses the codegen (RyuJIT) and RyuJIT supports x86 just fine, we can still generate x86.

This has some hackery though:

* We can't publish for the win-x86 RID because those packages are missing. So keep publishing as win-x64, but whack it to x86 when NativeAOT logic becomes concerned.
* x86 requires a bunch of assembly helpers with non-standard calling conventions. We need to write them in assembly :(
* x86 has a special mangling for x86 that ILC doesn't implement (I tried to implement it in the past in https://github.com/dotnet/corert/pull/7943). We need to whack the mangling into imported names. To find the right mangled name, just search strings in the appropriate LIB file (e.g. kernel32.lib).

I'm submitting it as a draft. It is kind of hacky. No hard feelings if you don't want to merge it.

The size numbers are much better on x86 because of more compact instruction encoding and smaller pointers: 1711 bytes for HelloWorld, 2299 bytes for Mandelbrot, 5832 bytes for Ocean.